### PR TITLE
feat: add non-interactive API commands and Torznab serve mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     "winotify; sys_platform == 'win32'"
 ]
 
+[project.optional-dependencies]
+serve = ["flask>=3.0", "pyyaml>=6.0"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["weeb_cli*"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,180 @@
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from typer.testing import CliRunner
+from weeb_cli.main import app
+from weeb_cli.providers.base import AnimeResult, Episode, StreamLink, AnimeDetails
+
+runner = CliRunner()
+
+MOCK_ANIME = AnimeResult(id="123", title="Angel Beats!", type="series")
+MOCK_EPISODES = [
+    Episode(id="ep1", number=1, title="Pilot", season=1),
+    Episode(id="ep2", number=2, title="Second", season=1),
+    Episode(id="ep3", number=1, title="S2 Pilot", season=2),
+]
+MOCK_STREAMS = [
+    StreamLink(url="https://example.com/video.mp4", quality="1080p", server="tau"),
+]
+MOCK_DETAILS = AnimeDetails(
+    id="123", title="Angel Beats!", description="A test", genres=["Drama"], year=2010,
+)
+
+
+def _mock_provider(**overrides):
+    p = MagicMock()
+    p.search.return_value = overrides.get("search", [MOCK_ANIME])
+    p.get_episodes.return_value = overrides.get("episodes", MOCK_EPISODES)
+    p.get_streams.return_value = overrides.get("streams", MOCK_STREAMS)
+    p.get_details.return_value = overrides.get("details", MOCK_DETAILS)
+    return p
+
+
+class TestApiProviders:
+
+    def test_providers_lists_all(self):
+        result = runner.invoke(app, ["api", "providers"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        names = [p["name"] for p in data]
+        assert "animecix" in names
+
+
+class TestApiSearch:
+
+    def test_search_returns_json(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()):
+            result = runner.invoke(app, ["api", "search", "Angel Beats"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 1
+            assert data[0]["id"] == "123"
+            assert data[0]["title"] == "Angel Beats!"
+
+    def test_search_empty(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider(search=[])):
+            result = runner.invoke(app, ["api", "search", "nonexistent"])
+            assert result.exit_code == 0
+            assert json.loads(result.output) == []
+
+
+class TestApiEpisodes:
+
+    def test_episodes_returns_all(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()):
+            result = runner.invoke(app, ["api", "episodes", "123"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 3
+
+    def test_episodes_filter_season(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()):
+            result = runner.invoke(app, ["api", "episodes", "123", "--season", "1"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 2
+            assert all(e["season"] == 1 for e in data)
+
+
+class TestApiStreams:
+
+    def test_streams_returns_json(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()):
+            result = runner.invoke(app, ["api", "streams", "123", "--episode", "1"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 1
+            assert data[0]["quality"] == "1080p"
+
+    def test_streams_episode_not_found(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()):
+            result = runner.invoke(app, ["api", "streams", "123", "--episode", "99"])
+            assert result.exit_code == 1
+
+
+class TestApiDetails:
+
+    def test_details_returns_json(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()):
+            result = runner.invoke(app, ["api", "details", "123"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["title"] == "Angel Beats!"
+            assert data["year"] == 2010
+
+    def test_details_not_found(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider(details=None)):
+            result = runner.invoke(app, ["api", "details", "123"])
+            assert result.exit_code == 1
+
+
+class TestApiDownload:
+
+    def test_download_success(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()), \
+             patch("weeb_cli.services.headless_downloader.download_episode", return_value="/tmp/test.mp4"):
+            result = runner.invoke(app, ["api", "download", "123", "--episode", "1", "--output", "/tmp"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["status"] == "ok"
+            assert data["anime"] == "Angel Beats!"
+
+    def test_download_episode_not_found(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider()):
+            result = runner.invoke(app, ["api", "download", "123", "--episode", "99"])
+            assert result.exit_code == 1
+
+    def test_download_no_streams(self):
+        with patch("weeb_cli.commands.api._get_provider", return_value=_mock_provider(streams=[])):
+            result = runner.invoke(app, ["api", "download", "123", "--episode", "1"])
+            assert result.exit_code == 1
+
+
+class TestApiDownloadUrl:
+
+    def test_download_url_success(self):
+        with patch("weeb_cli.services.headless_downloader.download_episode", return_value="/tmp/test.mp4"):
+            result = runner.invoke(app, [
+                "api", "download-url", "https://example.com/video.mp4",
+                "--title", "Test Anime", "--episode", "1", "--output", "/tmp",
+            ])
+            assert result.exit_code == 0
+            assert json.loads(result.output)["status"] == "ok"
+
+    def test_download_url_failure(self):
+        with patch("weeb_cli.services.headless_downloader.download_episode", return_value=None):
+            result = runner.invoke(app, [
+                "api", "download-url", "https://example.com/fail.mp4",
+                "--title", "Test Anime", "--episode", "1", "--output", "/tmp",
+            ])
+            assert result.exit_code == 1
+
+
+class TestHeadlessDownloader:
+
+    def test_sanitize_filename(self):
+        from weeb_cli.services.headless_downloader import _sanitize_filename
+        assert _sanitize_filename('Test: Anime / Name?') == "Test Anime Name"
+        assert _sanitize_filename('') == "unnamed"
+        assert _sanitize_filename('Normal Name') == "Normal Name"
+
+
+class TestDatabaseLazyInit:
+
+    def test_no_recursion_on_first_access(self, temp_dir):
+        """Regression test: lazy init must not cause infinite recursion."""
+        from weeb_cli.services.database import Database
+        db = Database()
+        db.db_path = temp_dir / "test.db"
+        db._initialized = False
+        assert db.get_config("language") is None
+        assert db._initialized is True
+
+    def test_set_and_get_config(self, temp_dir):
+        from weeb_cli.services.database import Database
+        db = Database()
+        db.db_path = temp_dir / "test.db"
+        db._initialized = False
+        db.set_config("language", "en")
+        assert db.get_config("language") == "en"

--- a/weeb_cli/commands/api.py
+++ b/weeb_cli/commands/api.py
@@ -1,0 +1,199 @@
+import json
+import sys
+import typer
+from typing import Optional
+
+api_app = typer.Typer(
+    name="api",
+    help="Non-interactive API commands for scripts, agents, and automation.",
+    add_completion=False,
+    invoke_without_command=True,
+)
+
+
+def _setup_headless():
+    from weeb_cli.config import config
+    config.set_headless(True)
+
+
+def _get_provider(name: str):
+    from weeb_cli.providers.registry import get_provider
+    provider = get_provider(name)
+    if provider is None:
+        typer.echo(json.dumps({"error": f"Unknown provider: {name}"}), err=True)
+        raise typer.Exit(1)
+    return provider
+
+
+def _output(data):
+    typer.echo(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def _quality_score(q: str) -> int:
+    q = (q or "").lower()
+    if "1080" in q:
+        return 3
+    if "720" in q:
+        return 2
+    if "480" in q:
+        return 1
+    return 0
+
+
+@api_app.callback()
+def api_callback(ctx: typer.Context):
+    _setup_headless()
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(0)
+
+
+@api_app.command()
+def providers():
+    """List all available providers."""
+    from weeb_cli.providers.registry import list_providers
+    _output(list_providers())
+
+
+@api_app.command()
+def search(
+    query: str = typer.Argument(..., help="Search query"),
+    provider: str = typer.Option("animecix", "--provider", "-p", help="Provider name"),
+):
+    """Search for anime by title. Returns a list with IDs to use in other commands."""
+    p = _get_provider(provider)
+    results = p.search(query)
+    _output([
+        {"id": r.id, "title": r.title, "type": r.type, "cover": r.cover, "year": r.year}
+        for r in results
+    ])
+
+
+@api_app.command()
+def episodes(
+    anime_id: str = typer.Argument(..., help="Anime ID from search results"),
+    season: Optional[int] = typer.Option(None, "--season", "-s", help="Filter by season number"),
+    provider: str = typer.Option("animecix", "--provider", "-p", help="Provider name"),
+):
+    """List episodes for an anime by ID."""
+    p = _get_provider(provider)
+    eps = p.get_episodes(anime_id)
+    if season is not None:
+        eps = [e for e in eps if e.season == season]
+    _output([
+        {"id": e.id, "number": e.number, "title": e.title, "season": e.season, "url": e.url}
+        for e in eps
+    ])
+
+
+@api_app.command()
+def streams(
+    anime_id: str = typer.Argument(..., help="Anime ID from search results"),
+    season: int = typer.Option(1, "--season", "-s", help="Season number"),
+    episode: int = typer.Option(..., "--episode", "-e", help="Episode number"),
+    provider: str = typer.Option("animecix", "--provider", "-p", help="Provider name"),
+):
+    """Get stream URLs for a specific episode by anime ID and episode number."""
+    p = _get_provider(provider)
+    eps = p.get_episodes(anime_id)
+    target = [e for e in eps if e.season == season and e.number == episode]
+    if not target:
+        _output({"error": f"Episode S{season:02d}E{episode:02d} not found"})
+        raise typer.Exit(1)
+    ep = target[0]
+    links = p.get_streams(anime_id, ep.id)
+    _output([
+        {"url": s.url, "quality": s.quality, "server": s.server, "headers": s.headers, "subtitles": s.subtitles}
+        for s in links
+    ])
+
+
+@api_app.command()
+def details(
+    anime_id: str = typer.Argument(..., help="Anime ID from search results"),
+    provider: str = typer.Option("animecix", "--provider", "-p", help="Provider name"),
+):
+    """Get anime details by ID."""
+    p = _get_provider(provider)
+    d = p.get_details(anime_id)
+    if d is None:
+        _output({"error": "Not found"})
+        raise typer.Exit(1)
+    _output({
+        "id": d.id, "title": d.title, "description": d.description, "cover": d.cover,
+        "genres": d.genres, "year": d.year, "status": d.status, "total_episodes": d.total_episodes,
+        "episodes": [
+            {"id": e.id, "number": e.number, "title": e.title, "season": e.season}
+            for e in d.episodes
+        ],
+    })
+
+
+@api_app.command()
+def download(
+    anime_id: str = typer.Argument(..., help="Anime ID from search results"),
+    season: int = typer.Option(1, "--season", "-s", help="Season number"),
+    episode: int = typer.Option(..., "--episode", "-e", help="Episode number"),
+    provider: str = typer.Option("animecix", "--provider", "-p", help="Provider name"),
+    output: str = typer.Option(".", "--output", "-o", help="Output directory"),
+):
+    """Download an episode by anime ID and episode number."""
+    from weeb_cli.services.headless_downloader import download_episode
+
+    p = _get_provider(provider)
+    eps = p.get_episodes(anime_id)
+    target = [e for e in eps if e.season == season and e.number == episode]
+    if not target:
+        _output({"status": "error", "message": f"Episode S{season:02d}E{episode:02d} not found"})
+        raise typer.Exit(1)
+
+    ep = target[0]
+    stream_links = p.get_streams(anime_id, ep.id)
+    if not stream_links:
+        _output({"status": "error", "message": "No streams available"})
+        raise typer.Exit(1)
+
+    stream_links.sort(key=lambda s: _quality_score(s.quality), reverse=True)
+
+    # Try to get the anime title for the filename
+    d = p.get_details(anime_id)
+    title = d.title if d else anime_id
+
+    for stream in stream_links:
+        result = download_episode(
+            stream_url=stream.url,
+            series_title=title,
+            season=season,
+            episode=episode,
+            download_dir=output,
+        )
+        if result:
+            _output({"status": "ok", "path": result, "anime": title, "quality": stream.quality})
+            return
+
+    _output({"status": "error", "message": "All streams failed"})
+    raise typer.Exit(1)
+
+
+@api_app.command(name="download-url", hidden=True)
+def download_url(
+    stream_url: str = typer.Argument(..., help="Direct stream URL to download"),
+    title: str = typer.Option(..., "--title", "-t", help="Series title for filename"),
+    season: int = typer.Option(1, "--season", "-s", help="Season number"),
+    episode: int = typer.Option(..., "--episode", "-e", help="Episode number"),
+    output: str = typer.Option(".", "--output", "-o", help="Output directory"),
+):
+    """Download a single episode from a direct stream URL."""
+    from weeb_cli.services.headless_downloader import download_episode
+    result = download_episode(
+        stream_url=stream_url,
+        series_title=title,
+        season=season,
+        episode=episode,
+        download_dir=output,
+    )
+    if result:
+        _output({"status": "ok", "path": result})
+    else:
+        _output({"status": "error", "message": "Download failed"})
+        raise typer.Exit(1)

--- a/weeb_cli/commands/serve.py
+++ b/weeb_cli/commands/serve.py
@@ -1,0 +1,464 @@
+"""Built-in Torznab-compatible server for Sonarr/*arr integration.
+
+Requires: pip install weeb-cli[serve]
+Usage:  weeb-cli serve --port 9876 --watch-dir /downloads/watch --completed-dir /downloads/completed
+"""
+import json
+import time
+import base64
+import hashlib
+import logging
+import re
+import sys
+import threading
+from difflib import SequenceMatcher
+from pathlib import Path
+from datetime import datetime, timezone
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+import typer
+
+log = logging.getLogger("weeb-cli")
+
+serve_app = typer.Typer(
+    name="serve",
+    help="Start a Torznab-compatible server for Sonarr/*arr integration.",
+    add_completion=False,
+)
+
+
+# -- Helpers ------------------------------------------------------------------
+
+def _sanitize_for_release(name: str) -> str:
+    name = re.sub(r'[<>:"/\\|?*]', "", name)
+    name = re.sub(r"[\s]+", ".", name).strip(".")
+    return name
+
+
+def _quality_score(q: str) -> int:
+    q = (q or "").lower()
+    if "1080" in q:
+        return 3
+    if "720" in q:
+        return 2
+    if "480" in q:
+        return 1
+    return 0
+
+
+def _make_guid(anime_id: str, season: int, episode: int, release_name: str) -> str:
+    raw = f"{anime_id}-{season}-{episode}-{release_name}"
+    return hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+
+def _encode_download_id(data: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(data).encode()).decode()
+
+
+def _decode_download_id(encoded: str) -> dict:
+    return json.loads(base64.urlsafe_b64decode(encoded.encode()).decode())
+
+
+# -- Sonarr integration -------------------------------------------------------
+
+def _sonarr_get_series_title(q: str, sonarr_url: str, sonarr_api_key: str) -> str | None:
+    if not sonarr_url or not sonarr_api_key:
+        return None
+    try:
+        import requests
+        resp = requests.get(
+            f"{sonarr_url}/api/v3/series",
+            headers={"X-Api-Key": sonarr_api_key},
+            timeout=5,
+        )
+        if resp.status_code != 200:
+            return None
+        series_list = resp.json()
+        q_lower = q.lower().strip()
+        q_stripped = re.sub(r"\s+\d+$", "", q_lower).strip()
+        q_variants = list(dict.fromkeys([q_lower, q_stripped]))
+
+        for q_try in q_variants:
+            q_clean = re.sub(r"[^a-z0-9]", "", q_try)
+            for series in series_list:
+                title = series.get("title", "")
+                if title.lower() == q_try:
+                    return title
+                clean_title = series.get("cleanTitle", "")
+                if clean_title and clean_title == q_clean:
+                    return title
+                for alt in series.get("alternateTitles", []):
+                    alt_title = alt.get("title", "").lower()
+                    alt_clean = re.sub(r"[^a-z0-9]", "", alt_title)
+                    if alt_title == q_try or alt_clean == q_clean:
+                        return title
+        return None
+    except Exception as e:
+        log.debug(f"Sonarr lookup failed: {e}")
+        return None
+
+
+# -- Torznab XML builders -----------------------------------------------------
+
+def _torznab_error(code: int, description: str):
+    from flask import Response
+    root = Element("error", code=str(code), description=description)
+    xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(root, encoding="unicode")
+    return Response(xml, mimetype="application/xml")
+
+
+def _torznab_caps_xml() -> str:
+    root = Element("caps")
+    SubElement(root, "server", version="1.0", title="weeb-cli")
+    SubElement(root, "limits", max="100", default="50")
+    searching = SubElement(root, "searching")
+    SubElement(searching, "search", available="yes", supportedParams="q")
+    SubElement(searching, "tv-search", available="yes", supportedParams="q,season,ep")
+    SubElement(searching, "movie-search", available="no")
+    categories = SubElement(root, "categories")
+    cat = SubElement(categories, "category", id="5000", name="TV")
+    SubElement(cat, "subcat", id="5030", name="TV/SD")
+    SubElement(cat, "subcat", id="5040", name="TV/HD")
+    SubElement(cat, "subcat", id="5070", name="TV/Anime")
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(root, encoding="unicode")
+
+
+def _build_torznab_rss(items: list) -> str:
+    root = Element("rss", version="2.0")
+    root.set("xmlns:torznab", "http://torznab.com/schemas/2015/feed")
+    root.set("xmlns:atom", "http://www.w3.org/2005/Atom")
+    channel = SubElement(root, "channel")
+    SubElement(channel, "title").text = "weeb-cli"
+
+    for it in items:
+        item = SubElement(channel, "item")
+        SubElement(item, "title").text = it["title"]
+        SubElement(item, "guid").text = it["guid"]
+        SubElement(item, "link").text = it["link"]
+        SubElement(item, "pubDate").text = datetime.now(timezone.utc).strftime(
+            "%a, %d %b %Y %H:%M:%S +0000"
+        )
+        SubElement(item, "category").text = "5070"
+        enc = SubElement(item, "enclosure")
+        enc.set("url", it["link"])
+        enc.set("length", str(it.get("size", 0)))
+        enc.set("type", "application/x-bittorrent")
+
+        for attr_name, attr_val in it.get("attrs", {}).items():
+            a = SubElement(item, "torznab:attr")
+            a.set("name", attr_name)
+            a.set("value", str(attr_val))
+
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(root, encoding="unicode")
+
+
+# -- Stream download helper ---------------------------------------------------
+
+def _try_streams(streams, sonarr_title, season, episode_num, completed_dir) -> bool:
+    from weeb_cli.services.headless_downloader import download_episode
+    if not streams:
+        return False
+    streams_sorted = sorted(streams, key=lambda s: _quality_score(s.quality), reverse=True)
+    for stream in streams_sorted:
+        log.info(f"  Trying stream: {stream.quality} @ {stream.server}")
+        result = download_episode(
+            stream_url=stream.url,
+            series_title=sonarr_title,
+            season=season,
+            episode=episode_num,
+            download_dir=completed_dir,
+        )
+        if result:
+            return True
+        log.warning(f"  Stream failed, trying next...")
+    return False
+
+
+def _get_fallback_streams(fallback_providers, sonarr_title, season, episode_num):
+    for fp in fallback_providers:
+        try:
+            log.info(f"  Fallback: trying {fp.name} for {sonarr_title} S{season:02d}E{episode_num:02d}")
+            results = fp.search(sonarr_title)
+            if not results:
+                continue
+            best = max(results, key=lambda r: SequenceMatcher(
+                None, sonarr_title.lower(), r.title.lower()
+            ).ratio())
+            log.info(f"  Fallback: {fp.name} matched '{best.title}' (id={best.id})")
+            episodes = fp.get_episodes(best.id)
+            target = [e for e in episodes if e.number == episode_num]
+            if not target:
+                continue
+            ep = target[0]
+            streams = fp.get_streams(best.id, ep.id)
+            if streams:
+                log.info(f"  Fallback: {fp.name} returned {len(streams)} stream(s)")
+                return streams
+        except Exception as e:
+            log.error(f"  Fallback: {fp.name} error: {e}")
+    return []
+
+
+# -- Main serve command -------------------------------------------------------
+
+@serve_app.callback(invoke_without_command=True)
+def serve(
+    ctx: typer.Context,
+    port: int = typer.Option(9876, "--port", envvar="FLASK_PORT", help="HTTP port"),
+    watch_dir: str = typer.Option("/downloads/weeb-cli/watch", "--watch-dir", envvar="WATCH_DIR", help="Blackhole watch directory"),
+    completed_dir: str = typer.Option("/downloads/weeb-cli/completed", "--completed-dir", envvar="COMPLETED_DIR", help="Completed downloads directory"),
+    config_dir: str = typer.Option("/config", "--config-dir", envvar="CONFIG_DIR", help="Config directory for mappings"),
+    poll_interval: int = typer.Option(5, "--poll-interval", envvar="POLL_INTERVAL", help="Blackhole poll interval in seconds"),
+    sonarr_url: str = typer.Option("", "--sonarr-url", envvar="SONARR_URL", help="Sonarr base URL"),
+    sonarr_api_key: str = typer.Option("", "--sonarr-api-key", envvar="SONARR_API_KEY", help="Sonarr API key"),
+    provider_names: str = typer.Option("animecix,anizle,turkanime", "--providers", envvar="PROVIDERS", help="Comma-separated provider names (first is primary)"),
+):
+    """Start a Torznab-compatible HTTP server for Sonarr/*arr integration."""
+    try:
+        from flask import Flask, request, Response
+    except ImportError:
+        typer.echo(
+            "Flask is required for serve mode. Install with: pip install weeb-cli[serve]",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    import yaml
+    from weeb_cli.config import config as weeb_config
+    weeb_config.set_headless(True)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stdout,
+    )
+
+    # Load providers
+    from weeb_cli.providers.registry import get_provider
+    all_providers = []
+    for name in provider_names.split(","):
+        name = name.strip()
+        p = get_provider(name)
+        if p:
+            all_providers.append(p)
+            log.info(f"Loaded provider: {name}")
+        else:
+            log.warning(f"Provider not found: {name}")
+
+    if not all_providers:
+        log.error("No providers loaded, exiting.")
+        raise typer.Exit(1)
+
+    primary = all_providers[0]
+    fallbacks = all_providers[1:]
+
+    # Config loader
+    def _load_mappings() -> dict:
+        config_path = Path(config_dir) / "config.yml"
+        if config_path.exists():
+            try:
+                with open(config_path) as f:
+                    cfg = yaml.safe_load(f) or {}
+                return cfg.get("mappings", {}) or {}
+            except Exception:
+                pass
+        return {}
+
+    # Flask app
+    flask_app = Flask(__name__)
+
+    @flask_app.route("/api", methods=["GET"])
+    def torznab_api():
+        t = request.args.get("t", "")
+        if t == "caps":
+            return Response(_torznab_caps_xml(), mimetype="application/xml")
+
+        if t in ("search", "tvsearch"):
+            q = request.args.get("q", "").strip()
+            season = request.args.get("season")
+            ep = request.args.get("ep")
+
+            if not q:
+                return Response(_build_torznab_rss([]), mimetype="application/xml")
+
+            mappings = _load_mappings()
+            search_term = mappings.get(q, q)
+            log.info(f"Torznab search: q={q} season={season} ep={ep} (search_term={search_term})")
+
+            results = primary.search(search_term)
+            if not results:
+                log.info(f"  No results for '{search_term}'")
+                return Response(_build_torznab_rss([]), mimetype="application/xml")
+
+            best = results[0]
+            log.info(f"  Best match: {best.title} (id={best.id})")
+
+            eps = primary.get_episodes(best.id)
+            if not eps:
+                return Response(_build_torznab_rss([]), mimetype="application/xml")
+
+            if season:
+                try:
+                    s_num = int(season)
+                    eps = [e for e in eps if e.season == s_num]
+                except ValueError:
+                    pass
+            if ep:
+                try:
+                    e_num = int(ep)
+                    eps = [e for e in eps if e.number == e_num]
+                except ValueError:
+                    pass
+
+            items = []
+            base_url = request.host_url.rstrip("/")
+            s_title = _sonarr_get_series_title(q, sonarr_url, sonarr_api_key) or q
+            release_series = _sanitize_for_release(s_title)
+
+            for episode in eps:
+                release_name = (
+                    f"{release_series}.S{episode.season:02d}E{episode.number:02d}"
+                    f".{primary.name}.1080p.WEB-DL.TR-WEEBCLI"
+                )
+                download_data = {
+                    "episode_url": episode.id,
+                    "anime_id": best.id,
+                    "sonarr_title": s_title,
+                    "season": episode.season,
+                    "episode": episode.number,
+                    "release_name": release_name,
+                }
+                dl_id = _encode_download_id(download_data)
+                dl_link = f"{base_url}/download?id={dl_id}"
+                guid = _make_guid(best.id, episode.season, episode.number, release_name)
+                items.append({
+                    "title": release_name,
+                    "guid": guid,
+                    "link": dl_link,
+                    "size": 2_000_000_000,
+                    "attrs": {
+                        "category": "5070",
+                        "seeders": "1",
+                        "leechers": "0",
+                        "peers": "1",
+                        "size": "2000000000",
+                        "minimumratio": "0",
+                        "minimumseedtime": "0",
+                    },
+                })
+
+            log.info(f"  Returning {len(items)} result(s)")
+            return Response(_build_torznab_rss(items), mimetype="application/xml")
+
+        return _torznab_error(202, f"Unsupported function: {t}")
+
+    @flask_app.route("/download", methods=["GET"])
+    def download_stub():
+        dl_id = request.args.get("id", "")
+        if not dl_id:
+            return "Missing id", 400
+        try:
+            data = _decode_download_id(dl_id)
+        except Exception:
+            return "Invalid id", 400
+
+        stub = {
+            "weeb-cli": True,
+            "episode_url": data.get("episode_url", ""),
+            "anime_id": data.get("anime_id", ""),
+            "sonarr_title": data.get("sonarr_title", ""),
+            "season": data["season"],
+            "episode": data["episode"],
+            "release_name": data.get("release_name", ""),
+            "created_at": time.time(),
+        }
+
+        wd = Path(watch_dir)
+        wd.mkdir(parents=True, exist_ok=True)
+        stub_name = f"{data.get('release_name', 'download')}.torrent"
+        stub_path = wd / stub_name
+        with open(stub_path, "w") as f:
+            json.dump(stub, f)
+        log.info(f"Created stub: {stub_path}")
+
+        torrent_bytes = json.dumps(stub).encode()
+        return Response(
+            torrent_bytes,
+            mimetype="application/x-bittorrent",
+            headers={"Content-Disposition": f"attachment; filename={stub_name}"},
+        )
+
+    # Blackhole worker
+    def blackhole_worker():
+        log.info(f"Blackhole worker started (watch={watch_dir}, completed={completed_dir})")
+        watch = Path(watch_dir)
+        completed = Path(completed_dir)
+        watch.mkdir(parents=True, exist_ok=True)
+        completed.mkdir(parents=True, exist_ok=True)
+
+        while True:
+            try:
+                for failed_file in watch.glob("*.failed"):
+                    try:
+                        age = time.time() - failed_file.stat().st_mtime
+                        if age > 300:
+                            retried = failed_file.with_suffix(".torrent")
+                            failed_file.rename(retried)
+                            log.info(f"Retrying: {retried.name}")
+                    except Exception:
+                        pass
+
+                for stub_file in watch.glob("*.torrent"):
+                    try:
+                        with open(stub_file) as f:
+                            stub = json.load(f)
+                        if not stub.get("weeb-cli"):
+                            continue
+
+                        episode_url = stub.get("episode_url", "")
+                        anime_id = stub.get("anime_id", "")
+                        s_title = stub.get("sonarr_title", "")
+                        s = stub["season"]
+                        ep_num = stub["episode"]
+                        release_name = stub.get("release_name", "")
+                        log.info(f"Processing stub: {release_name}")
+
+                        # Primary provider
+                        primary_streams = primary.get_streams(anime_id, episode_url)
+                        success = _try_streams(primary_streams, s_title, s, ep_num, str(completed))
+
+                        # Fallback providers
+                        if not success and fallbacks:
+                            log.info(f"Primary failed, trying fallback providers...")
+                            fb_streams = _get_fallback_streams(fallbacks, s_title, s, ep_num)
+                            success = _try_streams(fb_streams, s_title, s, ep_num, str(completed))
+
+                        if success:
+                            stub_file.unlink(missing_ok=True)
+                            log.info(f"Completed: {release_name}")
+                        else:
+                            stub_file.rename(stub_file.with_suffix(".failed"))
+                            log.error(f"Failed: {release_name}")
+
+                    except Exception as e:
+                        log.error(f"Error processing {stub_file.name}: {e}")
+                        try:
+                            stub_file.rename(stub_file.with_suffix(".failed"))
+                        except Exception:
+                            pass
+
+            except Exception as e:
+                log.error(f"Blackhole worker error: {e}")
+
+            time.sleep(poll_interval)
+
+    log.info("weeb-cli serve starting")
+    log.info(f"  Port: {port}")
+    log.info(f"  Watch dir: {watch_dir}")
+    log.info(f"  Completed dir: {completed_dir}")
+
+    worker = threading.Thread(target=blackhole_worker, daemon=True)
+    worker.start()
+
+    flask_app.run(host="0.0.0.0", port=port, debug=False)

--- a/weeb_cli/config.py
+++ b/weeb_cli/config.py
@@ -29,6 +29,7 @@ DEFAULT_CONFIG = {
 class Config:
     def __init__(self):
         self._db = None
+        self._headless = False
     
     @property
     def db(self):
@@ -38,15 +39,21 @@ class Config:
         return self._db
     
     def get(self, key, default=None):
-        val = self.db.get_config(key)
-        if val is None:
-            # Special handling for download_dir
-            if key == "download_dir":
-                return get_default_download_dir()
-            return DEFAULT_CONFIG.get(key, default)
-        return val
+        if not self._headless:
+            try:
+                val = self.db.get_config(key)
+                if val is not None:
+                    return val
+            except Exception:
+                pass
+        if key == "download_dir":
+            return get_default_download_dir()
+        return DEFAULT_CONFIG.get(key, default)
     
     def set(self, key, value):
         self.db.set_config(key, value)
+
+    def set_headless(self, headless: bool = True):
+        self._headless = headless
 
 config = Config()

--- a/weeb_cli/i18n.py
+++ b/weeb_cli/i18n.py
@@ -18,7 +18,10 @@ LOCALES_DIR = get_locales_dir()
 
 class I18n:
     def __init__(self):
-        self.language = config.get("language", "en")
+        try:
+            self.language = config.get("language", "en")
+        except Exception:
+            self.language = "en"
         self.translations = {}
         self.load_translations()
 

--- a/weeb_cli/main.py
+++ b/weeb_cli/main.py
@@ -13,8 +13,12 @@ from weeb_cli.commands.setup import start_setup_wizard
 from weeb_cli.services.dependency_manager import dependency_manager
 from weeb_cli.services.updater import update_prompt
 from weeb_cli.ui.prompt import prompt
+from weeb_cli.commands.api import api_app
+from weeb_cli.commands.serve import serve_app
 
 app = typer.Typer(add_completion=False)
+app.add_typer(api_app, name="api")
+app.add_typer(serve_app, name="serve")
 console = Console()
 
 def check_network():

--- a/weeb_cli/providers/animecix.py
+++ b/weeb_cli/providers/animecix.py
@@ -167,7 +167,7 @@ class AnimeCixProvider(BaseProvider):
                     id=ep_url,
                     number=ep_num,
                     title=name,
-                    season=sidx + 1,
+                    season=self._parse_season_from_url(ep_url, sidx + 1),
                     url=ep_url
                 ))
         
@@ -274,3 +274,10 @@ class AnimeCixProvider(BaseProvider):
                 return int(match.group(1))
         
         return fallback
+
+    def _parse_season_from_url(self, url: str, fallback: int) -> int:
+        try:
+            qs = parse_qs(url.split("?", 1)[1]) if "?" in url else {}
+            return int(qs["season"][0])
+        except (KeyError, IndexError, ValueError):
+            return fallback

--- a/weeb_cli/services/headless_downloader.py
+++ b/weeb_cli/services/headless_downloader.py
@@ -1,0 +1,109 @@
+"""Headless download module that works without database, TUI, or i18n dependencies.
+
+Used by the API commands and the Torznab serve mode.
+"""
+import logging
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+log = logging.getLogger("weeb-cli")
+
+
+def _find_tool(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def _sanitize_filename(name: str) -> str:
+    name = re.sub(r'[<>:"/\\|?*]', "", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    name = name.rstrip(".")
+    return name or "unnamed"
+
+
+def download_episode(
+    stream_url: str,
+    series_title: str,
+    season: int,
+    episode: int,
+    download_dir: str,
+) -> str | None:
+    safe_title = _sanitize_filename(series_title)
+    anime_dir = Path(download_dir)
+    anime_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = f"{safe_title} - S{season:02d}E{episode:02d}.mp4"
+    output_path = anime_dir / filename
+
+    if output_path.exists():
+        log.info(f"Already exists: {output_path}")
+        return str(output_path)
+
+    temp_path = output_path.with_suffix(".mp4.part")
+
+    is_hls = ".m3u8" in stream_url
+
+    try:
+        if is_hls:
+            _download_hls(stream_url, temp_path)
+        else:
+            aria2 = _find_tool("aria2c")
+            if aria2:
+                _download_aria2(aria2, stream_url, temp_path)
+            else:
+                _download_ffmpeg(stream_url, temp_path)
+
+        if temp_path.exists() and temp_path.stat().st_size > 0:
+            temp_path.rename(output_path)
+            log.info(f"Downloaded: {output_path}")
+            return str(output_path)
+        else:
+            log.error(f"Download produced empty file: {temp_path}")
+            temp_path.unlink(missing_ok=True)
+            return None
+
+    except Exception as e:
+        log.error(f"Download failed for {filename}: {e}")
+        temp_path.unlink(missing_ok=True)
+        return None
+
+
+def _download_aria2(aria2_path: str, url: str, output_path: Path):
+    cmd = [
+        aria2_path, url,
+        "-d", str(output_path.parent),
+        "-o", output_path.name,
+        "-x", "16", "-s", "16", "-j", "1", "-c",
+        "--console-log-level=warn",
+        "--summary-interval=5",
+        "--file-allocation=none",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+    if result.returncode != 0:
+        raise RuntimeError(f"aria2 failed (rc={result.returncode}): {result.stderr[:500]}")
+
+
+def _download_hls(url: str, output_path: Path):
+    ytdlp = _find_tool("yt-dlp")
+    if ytdlp:
+        cmd = [ytdlp, "-f", "best", "-o", str(output_path), "--no-part", url]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+        if result.returncode != 0:
+            raise RuntimeError(f"yt-dlp failed (rc={result.returncode}): {result.stderr[:500]}")
+    else:
+        _download_ffmpeg(url, output_path)
+
+
+def _download_ffmpeg(url: str, output_path: Path):
+    ffmpeg = _find_tool("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("No download tool available (need aria2c, yt-dlp, or ffmpeg)")
+    cmd = [
+        ffmpeg, "-i", url,
+        "-c", "copy", "-bsf:a", "aac_adtstoasc",
+        "-y", str(output_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+    if result.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed (rc={result.returncode}): {result.stderr[:500]}")


### PR DESCRIPTION
Adds `weeb-cli api` subcommands (search, episodes, streams, details, download, providers) that output JSON and work headlessly without requiring the database, TUI, or i18n subsystems.

Adds `weeb-cli serve` command that starts a Torznab-compatible HTTP server with a blackhole download worker for Sonarr/*arr integration.

Key changes:
  - Lazy database initialization (no dir creation until first DB call)
  - Headless config mode (skips DB reads when set_headless=True)
  - Graceful i18n fallback when database is unavailable
  - Headless downloader (aria2/yt-dlp/ffmpeg, no DB/TUI dependencies)
  - Optional flask dependency via pip install weeb-cli[serve]
  - Fix animecix season assignment bug for multi-season anime
  - 17 new tests, all 54 tests passing

Closes #4